### PR TITLE
remove viziality / powercord  from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,7 @@ git clone https://github.com/NYRI4/Comfy
 2. Save the file into your theme folder
 
 ## 🖌️ Customization
-Go into your theme folder > Comfy > support
-- For BetterDiscord : `comfy.theme.css`
-- For Powercord/Vizality : `_custom.css`
+Go into your theme folder > `comfy.theme.css` and edit whatever you like!
 
 ## Credits
 


### PR DESCRIPTION
Removed customization section for viziality / powercord because they are in seperate repos now.